### PR TITLE
lock flake-compat to root's input

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ Afterwards, create a `default.nix` file containing the following:
 let
   lock = builtins.fromJSON (builtins.readFile ./flake.lock);
 
-  inherit (lock.nodes.flake-compat.locked) owner repo rev narHash;
+  root = lock.nodes.${lock.root};
+  inherit (lock.nodes.${root.inputs.flake-compat}.locked) owner repo rev narHash;
 
   flake-compat = fetchTarball {
     url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz";


### PR DESCRIPTION
This isn't *often* relevant. But if you have inputs that themselves have a `flake-compat` input, you can end up using those by mistake. This locks the version used by `default.nix` to the input of the root node instead of which ever input happens to take the `flake-compat` name first.

For example, I had my flake set up with #4, and eventually my `default.nix` stopped working because one of my inputs got updated and its `flake-compat` input ended up taking the `flake-compat` name in `flake.lock`, while mine was under `flake-compat_2`.